### PR TITLE
Изменить логику словаря. Поиск производится по региону, а не по компании

### DIFF
--- a/advertising_data.txt
+++ b/advertising_data.txt
@@ -1,5 +1,4 @@
 Яндекс.Директ:/ru
-:/ru
 Ревдинский рабочий:/ru/svrd/revda,/ru/svrd/pervik
 Газета уральских москвичей:/ru/msk,/ru/permobl,/ru/chelobl
 Крутая реклама:/ru/svrd

--- a/src/Application/Ad/AdService.cs
+++ b/src/Application/Ad/AdService.cs
@@ -54,13 +54,10 @@ public sealed class AdService : IAdService
                 "\"Ad companies data is missing. Please, load data before requesting any information.\"");
         }
 
-        var regionPrefixes = GetRegionPrefixes(region);
-
-        return _adCompanyRepository.Get()
-            .Where(ad => ad.Value.Regions
-                .Any(r => regionPrefixes.Contains(r) || regionPrefixes.Any(prefix => r.EndsWith(prefix))))
-            .Select(ad => new AdCompanyModel(ad.Key, ad.Value.Regions))
-            .ToList();
+       var adCompanies = _adCompanyRepository.Get();
+       
+       return adCompanies[region].Select(x => 
+           new AdCompanyModel(x.CompanyName, x.Regions)).ToList();
     }
 
     private IReadOnlyList<string> GetRegionPrefixes(string region)

--- a/src/Repository/AdCompanyRepository.cs
+++ b/src/Repository/AdCompanyRepository.cs
@@ -5,22 +5,30 @@ namespace Repository;
 
 public sealed class AdCompanyRepository : IAdCompanyRepository
 {
-    private static readonly Dictionary<string, AdCompanyEntity> _adCompanies 
-        = new Dictionary<string, AdCompanyEntity>();
+    private static readonly Dictionary<string, List<AdCompanyEntity>> _regions 
+        = new Dictionary<string, List<AdCompanyEntity>>(StringComparer.OrdinalIgnoreCase);
 
     public void Add(string companyName, List<string> regions)
     {
-        _adCompanies[companyName] = new AdCompanyEntity(companyName, regions);
+        foreach (var region in regions)
+        {
+            if (!_regions.ContainsKey(region))
+            {
+                _regions[region] = new List<AdCompanyEntity>();
+            }
+
+            _regions[region].Add(new AdCompanyEntity(companyName, regions));
+        }
     }
 
-    public Dictionary<string, AdCompanyEntity> Get()
+    public Dictionary<string, List<AdCompanyEntity>> Get()
     {
-        return _adCompanies;
+        return _regions;
     }
 
     public void PurgeData()
     {
-        _adCompanies.Clear();
+        _regions.Clear();
     }
 
     private async Task<Dictionary<string, List<string>>> ParseRegionsFromALocalFileAsync(string filePath)

--- a/src/Repository/IAdCompanyRepository.cs
+++ b/src/Repository/IAdCompanyRepository.cs
@@ -6,7 +6,7 @@ public interface IAdCompanyRepository
 {
     public void Add(string companyName, List<string> regions);
 
-    public Dictionary<string, AdCompanyEntity> Get();
+    public Dictionary<string, List<AdCompanyEntity>> Get();
 
     public void PurgeData();
 }


### PR DESCRIPTION
Ранее поиск в словаре производился по компании, которая имела регионы. Такой обход имеет время поиска О(n).
Теперь же все происходит наоборот. Ключом в словаре является регион, а значением - коллекция подходящих компаний 